### PR TITLE
Update help output to match changes in 9d616a0

### DIFF
--- a/Tag/Tag.m
+++ b/Tag/Tag.m
@@ -386,9 +386,9 @@ typedef NS_ENUM(int, CommandCode) {
            "        -T | --no-tags      Turn off tags display in output (list)\n"
            "        -g | --garrulous    Display tags each on own line (list, find, match)\n"
            "        -G | --no-garrulous Display tags comma-separated after filename (default)\n"
-           "        -H | --home         Find tagged files in user home directory\n"
-           "        -L | --local        Find tagged files in home + local filesystems\n"
-           "        -R | --network      Find tagged files in home + local + network filesystems\n"
+           "           | --home         Find tagged files in user home directory\n"
+           "           | --local        Find tagged files in home + local filesystems\n"
+           "           | --network      Find tagged files in home + local + network filesystems\n"
            "        -0 | --nul          Terminate lines with NUL (\\0) for use with xargs -0\n"
     );
 }


### PR DESCRIPTION
Changes in 9d616a0 to the -H -L -R options has not been reflected in the output of -h/--help and is confusing to users when the listed short options do not work (or potentially when -R causes recursion, but the user intended --network), so this simply removes those non-functional short options from the help/usage output.

(Also, I wasn't sure if it was more helpful to leave the vertical bars in those lines or remove them. But it looks cleaner to me to have them... even though they're usually there to mean "OR". Do with those as you will.)