### PR TITLE
Improve install recipe and add uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 prefix		= /usr/local
 DESTDIR		= 
 
-DSTUSR		= root
+DSTUSR		= ${USER}
 DSTGRP		= admin
 DSTMODE		= 0755
 MANMODE		= 0644
@@ -34,7 +34,13 @@ clean:
 distclean: clean
 
 install: tag
+	mkdir -p ${DESTDIR}${BINDIR}
+	mkdir -p ${DESTDIR}${MANDIR}
 	${INSTALL} -o ${DSTUSR} -g ${DSTGRP} -m ${DSTMODE} ${PROGRAM} ${DESTDIR}${BINDIR}
 	${INSTALL} -o ${DSTUSR} -g ${DSTGRP} -m ${MANMODE} ${MANPAGE} ${DESTDIR}${MANDIR}
 
-.PHONY: all tag clean distclean install
+uninstall:
+	rm -f ${DESTDIR}${BINDIR}/$(notdir ${PROGRAM})
+	rm -f ${DESTDIR}${MANDIR}/$(notdir ${MANPAGE})
+
+.PHONY: all tag clean distclean install uninstall


### PR DESCRIPTION
Motivated by [discussions](https://discourse.brew.sh/t/tag-formula-using-make-install-vs-manually-installing/4926) on the Homebrew formula for _tag_, this pull request aims to improve the project Makefile.

Although it allows the use of a custom installation prefix, the current `install` recipe does not create the _bin_ and _share/man/man1_ directories itself. Moreover, having the default user set to root requires `sudo` on install (unless specified) even on non-root prefixes.

These improvements to the install recipe also have the side-effect of creating a cleaner Homebrew formula.
