### PR TITLE
Remove 'qq' that was in `man` page

### DIFF
--- a/Tag/tag.1
+++ b/Tag/tag.1
@@ -83,7 +83,7 @@ Find tagged files in user home directory
 .BR "    \-\-local"
 Find tagged files in home + local filesystems
 .TP
-.BR "    \-\-network"qq
+.BR "    \-\-network"
 Find tagged files in home + local + network filesystems
 .
 .SH BUGS


### PR DESCRIPTION
Minor fix for what appears to be a vim mistake.